### PR TITLE
Add sanity to u-boot build environment

### DIFF
--- a/NORTHWOOD.md
+++ b/NORTHWOOD.md
@@ -1,0 +1,20 @@
+# Northwood Altera U-Boot
+
+## Developer Environment
+```bash
+$ nix develop .#
+```
+
+This will drop you into a shell with all of the required tools to compile U-Boot, including symlinking our Arm Trusted Firmware (ATF) BL31 binary.
+
+### menuconfig
+Uncomment out `# menuconfig = true` in the `flake.nix` and reenter your shell with `nix develop .#`
+
+### xconfig
+Uncomment out `# xconfig = true` in the `flake.nix` and reenter your shell with `nix develop .#`
+
+## Building
+For instructions on how to build U-Boot, please follow upstream U-Boot documentation or Altera's [Building Bootloader for Stratix10](https://www.rocketboards.org/foswiki/Documentation/BuildingBootloaderStratix10).
+To simplify automation, there is a `justfile` at the root of this repository that will build the bootloader for you.
+Listing the current commands and their functionality can be done using `just --list`
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,304 @@
+{
+  "nodes": {
+    "attic": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1738524606,
+        "narHash": "sha256-hPYEJ4juK3ph7kbjbvv7PlU1D9pAkkhl+pwx8fZY53U=",
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "rev": "ff8a897d1f4408ebbf4d45fa9049c06b3e1e3f4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "rev": "ff8a897d1f4408ebbf4d45fa9049c06b3e1e3f4e",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722960479,
+        "narHash": "sha256-NhCkJJQhD5GUib8zN9JrmYGMwt4lCRp6ZVNzIiYCl0Y=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "4c6c77920b8d44cd6660c1621dea6b3fc4b4c4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1740485968,
+        "narHash": "sha256-WK+PZHbfDjLyveXAxpnrfagiFgZWaTJglewBWniTn2Y=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "19c1140419c4f1cdf88ad4c1cfb6605597628940",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "19c1140419c4f1cdf88ad4c1cfb6605597628940",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "northwood-nixpkgs",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741701235,
+        "narHash": "sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3+91651y3Sqo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c630dfa8abcc65984cc1e47fb25d4552c81dd37e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734083684,
+        "narHash": "sha256-5fNndbndxSx5d+C/D0p/VF32xDiJCJzyOqorOYW4JEo=",
+        "type": "tarball",
+        "url": "https://github.com/nixos/nixpkgs/archive/314e12ba369ccdb9b352a4db26ff419f7c49fa84.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/nixos/nixpkgs/archive/314e12ba369ccdb9b352a4db26ff419f7c49fa84.tar.gz"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1724316499,
+        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "northwood-nixpkgs": {
+      "inputs": {
+        "attic": "attic",
+        "disko": "disko",
+        "flake-compat": "flake-compat_2",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "sops-nix": "sops-nix"
+      },
+      "locked": {
+        "lastModified": 1743119614,
+        "narHash": "sha256-Rx176Jy8V0nplbZRPbmWAKjUoQlmB9B6+ww3/thd6Q4=",
+        "ref": "main",
+        "rev": "4388c8560e03ce7b45b74c49245a61d719a64fbe",
+        "revCount": 68,
+        "type": "git",
+        "url": "ssh://git@github.com/Northwood-Space/northwood-nixpkgs"
+      },
+      "original": {
+        "ref": "main",
+        "rev": "4388c8560e03ce7b45b74c49245a61d719a64fbe",
+        "type": "git",
+        "url": "ssh://git@github.com/Northwood-Space/northwood-nixpkgs"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "northwood-nixpkgs": "northwood-nixpkgs"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742700801,
+        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    northwood-nixpkgs.url = "git+ssh://git@github.com/Northwood-Space/northwood-nixpkgs?ref=main&rev=4388c8560e03ce7b45b74c49245a61d719a64fbe";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, northwood-nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let pkgs = northwood-nixpkgs.legacyPackages.${system};
+        in {
+          devShells.default = import ./shell.nix {
+            inherit system pkgs;
+            # If you would like to use menuconfig or xconfig to configure your image,
+            # then comment out one of the following lines.
+            #
+            # By default, we do not want to pull in the dependencies these require.
+
+            # menuconfig = true;
+            # xconfig = true;
+          };
+        }
+      );
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,30 @@
+# Run all required cleaning commands
+[group('Build')]
+clean:
+  make clean && make mrproper
+
+[group('Build')]
+build:
+  just beamformer
+
+# Build the Beamformer U-Boot
+[group('Build')]
+build-beamformer:
+  make -j$(nproc) $makeFlags
+
+# Generate .config for the beamformer defconfig
+[group('Build')]
+configure-beamformer:
+  make nw-beamformer_defconfig
+
+# Configure and build the beamformer U-Boot
+[group('Build')]
+beamformer:
+  just configure-beamformer
+  just link-bl31
+  just build-beamformer
+
+# Link arm trusted firmware into root directory. Replacing if it already exists
+[group('Build')]
+link-bl31:
+  ln -sf $BL31 .

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,43 @@
+{ pkgs ? import <nixpkgs> {}
+, target ? "aarch64-multiplatform"
+, system
+# Optionally add dependencies for xconfig and menu config 
+, menuconfig ? false
+, xconfig ? false
+}:
+let
+  # If we are aarch64-linux, then we do not need a cross-toolchain.
+  # Otherwise, grab the pkgsCross
+  #
+  # Notes on cross-compilation
+  # https://nixos.wiki/wiki/Cross_Compiling#Lazy_cross-compiling
+  # https://matthewbauer.us/blog/beginners-guide-to-cross.html
+  shouldCross = system == "aarch64-linux";
+  pkgsCross =
+    if shouldCross
+    then builtins.trace "using native pkgs" pkgs
+    else builtins.trace "using pkgsCross" pkgs.pkgsCross.${target};
+  # Even if we are cross-compiling we still want the pkg-config and friends for the machine we are building on, not building for.
+  pkgsBuild = pkgsCross.buildPackages;
+  menuconfigAttrs = if menuconfig then [ pkgsBuild.pkg-config pkgsBuild.ncurses ] else [];
+  xconfigAttrs = if xconfig then [ pkgsBuild.pkg-config pkgsBuild.qt5.qtbase ] else [];
+  # We want to use the same build environment that our nix derivation uses but with some new friends.
+  #
+  # This is why we choose to use overrideAttrs
+  # https://ryantm.github.io/nixpkgs/using/overrides/#sec-pkg-overrideAttrs
+  drv = pkgsCross.altera-u-boot.overrideAttrs(final: prev: {
+    # give it a new name so we can differentiate between nix build derivations and nix shell roots
+    pname = "northwood-u-boot";
+    nativeBuildInputs = builtins.concatLists [
+      # our build tools for
+      prev.nativeBuildInputs
+      # add our optional inputs
+      menuconfigAttrs
+      xconfigAttrs
+    ];
+    shellHook = ''
+      echo "ATF Binary located at: ${prev.BL31}"
+    '';
+  });
+in
+drv


### PR DESCRIPTION
- Adds the ability to dev locally without having to interface with Nix directly (well... mostly).
- Manage higher level commands using `Justfile` instead of `make`


Enter the developer shell. 

```bash
northwood@system76-pc ~/d/c/n/u-boot-socfpga (devshell)> nix develop .#
trace: using pkgsCross
ATF Binary located at: /nix/store/7l71yr8f04saypi0713hz8snkfvaqfpb-arm-trusted-firmware-aarch64-unknown-linux-gnu/bl31.bin
```

List all options
```bash
(nix:northwood-u-boot-aarch64-unknown-linux-gnu-0.1.0-env) northwood@system76-pc:~/development/cameron/northwood/u-boot-socfpga$ just --list
Available recipes:
    [Build]
    beamformer           # Configure and build the beamformer U-Boot
    build
    build-beamformer     # Build the Beamformer U-Boot
    clean                # Run all required cleaning commands
    configure-beamformer # Generate .config for the beamformer defconfig
    link-bl31            # Link arm trusted firmware into root directory. Replacing if it already exists
```

Do the things
```bash
(nix:northwood-u-boot-aarch64-unknown-linux-gnu-0.1.0-env) northwood@system76-pc:~/development/cameron/northwood/u-boot-socfpga$ just build
just beamformer
just configure-beamformer
make nw-beamformer_defconfig
arch/../configs/nw-beamformer_defconfig:122:warning: override: reassigning to symbol SYS_NAND_U_BOOT_LOCATIONS
#
# configuration written to .config
#
just link-bl31
ln -sf $BL31 .
just build-beamformer
make -j$(nproc) $makeFlags
scripts/kconfig/conf  --syncconfig Kconfig
  CFG     u-boot.cfg
  GEN     include/autoconf.mk.dep
  CFG     spl/u-boot.cfg
  GEN     include/autoconf.mk
  GEN     spl/include/autoconf.mk
  ENVC    include/generated/env.txt
  ENVP    include/generated/env.in
  ENVT    include/generated/environment.h
  UPD     include/config/uboot.release
  UPD     include/generated/version_autogenerated.h
  HOSTCC  tools/mkenvimage.o
  HOSTCC  tools/fit_image.o
  HOSTCC  tools/image-host.o
  HOSTCC  tools/dumpimage.o
  HOSTCC  tools/mkimage.o
  HOSTLD  tools/mkenvimage
  HOSTLD  tools/dumpimage
  HOSTLD  tools/mkimage
  HOSTLD  tools/fit_info
  HOSTLD  tools/fit_check_sign
  HOSTLD  tools/fdt_add_pubkey
  CC      boot/fdt_support.o
  CC      cmd/version.o
  AR      cmd/built-in.o
  CC      env/common.o
  CC      lib/smbios.o
  AR      env/built-in.o
  AR      lib/built-in.o
  AR      boot/built-in.o
  LD      u-boot
  OBJCOPY u-boot.srec
  OBJCOPY u-boot-nodtb.bin
  SYM     u-boot.sym
  RELOC   u-boot-nodtb.bin
  CAT     u-boot-dtb.bin
  MKIMAGE u-boot.img
  MKIMAGE u-boot-dtb.img
  COPY    u-boot.bin
  CC      spl/boot/fdt_support.o
  CC      spl/common/spl/spl.o
  AR      spl/common/spl/built-in.o
  AR      spl/boot/built-in.o
  LD      spl/u-boot-spl
  OBJCOPY spl/u-boot-spl-nodtb.bin
  SYM     spl/u-boot-spl.sym
  CAT     spl/u-boot-spl-dtb.bin
  COPY    spl/u-boot-spl.bin
  OBJCOPY spl/u-boot-spl-dtb.hex
  BINMAN  .binman_stamp
  OFCHK   .config
(nix:northwood-u-boot-aarch64-unknown-linux-gnu-0.1.0-env) northwood@system76-pc:~/development/cameron/northwood/u-boot-socfpga$ ls
0001-it-works-dont-fucking-touch-it.patch  cmd        dts         justfile     net           System.map  u-boot-dtb.bin  u-boot.lds
0001-remove-stupid-shit.patch              common     env         Kbuild       NORTHWOOD.md  test        u-boot-dtb.img  u-boot.map
api                                        config.mk  examples    Kconfig      post          tools       u-boot.dtb.out  u-boot-nodtb.bin
arch                                       configs    flake.lock  lib          README        u-boot      u-boot.fit.fit  u-boot-spl.dtb.out
bl31.bin                                   disk       flake.nix   Licenses     scripts       u-boot.bin  u-boot.fit.itb  u-boot.srec
board                                      doc        fs          MAINTAINERS  shell.nix     u-boot.cfg  u-boot.img      u-boot.sym
boot                                       drivers    include     Makefile     spl           u-boot.dtb  u-boot.itb
(nix:northwood-u-boot-aarch64-unknown-linux-gnu-0.1.0-env) northwood@system76-pc:~/development/cameron/northwood/u-boot-socfpga$ file u-boot
u-boot: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
```

Clean up after yourself
```bash
(nix:northwood-u-boot-aarch64-unknown-linux-gnu-0.1.0-env) northwood@system76-pc:~/development/cameron/northwood/u-boot-socfpga$ just clean
make clean && make mrproper
  CLEAN   dts/../arch/arm/dts
  CLEAN   dts
  CLEAN   lib/efi_loader
  CLEAN   tools
  CLEAN   tools/generated
  CLEAN   spl/arch spl/boot spl/cmd spl/common spl/disk spl/drivers spl/dts spl/env spl/fs spl/lib spl/u-boot-spl spl/u-boot-spl-dtb.bin spl/u-boot-spl-dtb.hex spl/u-boot-spl-nodtb.bin spl/u-boot-spl.bin spl/u-boot-spl.dtb spl/u-boot-spl.lds spl/u-boot-spl.map spl/u-boot-spl.sym spl/u-boot.cfg
  CLEAN   include/autoconf.mk include/autoconf.mk.dep include/config.h include/generated/env.in include/generated/env.txt u-boot u-boot.bin u-boot.cfg u-boot.dtb u-boot-dtb.bin u-boot-dtb.img u-boot.dtb.out u-boot.fit.fit u-boot.fit.itb u-boot.img u-boot.itb u-boot.lds u-boot.map u-boot-nodtb.bin u-boot-spl.dtb.out u-boot.srec u-boot.sym System.map u-boot.fit.itb u-boot.itb
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   include/config include/generated spl
  CLEAN   .config .config.old
```