### PR TITLE
northwood: update bootcmd to support sourcing script from fit image

### DIFF
--- a/configs/nw-beamformer_defconfig
+++ b/configs/nw-beamformer_defconfig
@@ -102,7 +102,7 @@ CONFIG_PANIC_HANG=y
 
 # Boot support
 CONFIG_BOOTFILE="Image"
-CONFIG_BOOTCOMMAND="bridge enable ; dhcp ; bootm"
+CONFIG_BOOTCOMMAND="bridge enable ; dhcp ; source ${loadaddr}:bootscript ; bootm"
 CONFIG_QSPI_BOOT=y
 CONFIG_BOOTDELAY=5
 CONFIG_USE_BOOTARGS=y

--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+default:
+  just --list
+
 # Run all required cleaning commands
 [group('Build')]
 clean:


### PR DESCRIPTION
- Run u-boot script attached to fit image in https://github.com/Northwood-Space/northwood-nixpkgs/pull/40
- Add default justfile argument
 

```bash
U-Boot 2024.01-g9ced07ad-dirty (Jan 01 1980 - 00:00:00 +0000)socfpga_stratix10

CPU:   Intel FPGA SoCFPGA Platform (ARMv8 64bit Cortex-A53)
Model: SoCFPGA Stratix 10 SoCDK
DRAM:  2 GiB
Core:  19 devices, 16 uclasses, devicetree: separate
WDT:   Started watchdog@ffd00200 with servicing every 1000ms (10s timeout)
MMC:
Loading Environment from SPIFlash... SF: Detected mt25qu02g with page size 256 Bytes, erase size 64 KiB, total 256 MiB
OK
In:    serial1@ffc02100
Out:   serial1@ffc02100
Err:   serial1@ffc02100
Net:   eth1: ethernet@ff802000
Hit any key to stop autoboot:  0
Speed: 1000, full duplex
BOOTP broadcast 1
BOOTP broadcast 2
BOOTP broadcast 3
BOOTP broadcast 4
DHCP client bound to address 172.16.0.102 (1757 ms)
Using ethernet@ff802000 device
TFTP from server 172.16.0.0; our IP address is 172.16.0.102
Filename 'kernel.itb'.
Load address: 0x1000000
Loading: #################################################################
done
Bytes transferred = 319174106 (130635da hex)
## Executing script at 01000000
## Loading kernel from FIT Image at 01000000 ...
   Using 'board-0' configuration
   Trying 'kernel' kernel subimage
     Description:  Linux Kernel
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x010000cc
     Data Size:    11401306 Bytes = 10.9 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x20000000
     Entry Point:  0x20000000
     Hash algo:    crc32
     Hash value:   475212e4
   Verifying Hash Integrity ... crc32+ OK
## Loading ramdisk from FIT Image at 01000000 ...
   Using 'board-0' configuration
   Trying 'initrd' ramdisk subimage
     Description:  Big Chungus Amongus (Beamformer netboot initrd)
     Type:         RAMDisk Image
     Compression:  uncompressed
     Data Start:   0x01ae4154
     Data Size:    307752451 Bytes = 293.5 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: unavailable
     Entry Point:  unavailable
     Hash algo:    crc32
     Hash value:   8cd17976
   Verifying Hash Integrity ... crc32+ OK
## Loading fdt from FIT Image at 01000000 ...
   Using 'board-0' configuration
   Trying 'fdt-0' fdt subimage
     Description:  socfpga_socdk
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x01adfa04
     Data Size:    18055 Bytes = 17.6 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   c9fcd6aa
   Verifying Hash Integrity ... crc32+ OK
   Booting using the fdt blob at 0x1adfa04
Working FDT set to 1adfa04
   Uncompressing Kernel Image
   Loading Ramdisk to 6c574000, end 7eaf2e03 ... OK
   Loading Device Tree to 000000006c56c000, end 000000006c573686 ... OK
Working FDT set to 6c56c000
SF: Detected mt25qu02g with page size 256 Bytes, erase size 64 KiB, total 256 MiB
Enabling QSPI at Linux DTB...
Working FDT set to 6c56c000
libfdt fdt_path_offset() returned FDT_ERR_NOTFOUND
libfdt fdt_path_offset() returned FDT_ERR_NOTFOUND
QSPI clock frequency updated
RSU: Firmware or flash content not supporting RSU
RSU: Firmware or flash content not supporting RSU
RSU: Firmware or flash content not supporting RSU
RSU: Firmware or flash content not supporting RSU

Starting kernel ...

Deasserting all peripheral resets
[    0.200537] spi_altera f9090000.spi: drivers/spi/spi-altera-platform.c:altera_spi_probe:70 using default host config.
[    0.202248] spi_altera f9090000.spi: error -ENXIO: IRQ index 0 not found
[    2.163655] spi_master (null): CS Override using dw_spi_exec_mem_op
[    2.166810] spi_master (null): CS Override using dw_spi_exec_mem_op

<<< NixOS Stage 1 >>>

loading module loop...
loading module overlay...
loading module dm_mod...
running udev...
Starting systemd-udevd version 256.8
kbd_mode: KDSKBMODE: Inappropriate ioctl for device
starting device mapper and LVM...
File descriptor 8 (/dev/console) leaked on lvm invocation. Parent PID 1: /nix/store/g5d2xbgp9js6phwlvkjbkpy6gf1cfj06-extra-utils/bin/ash
File descriptor 9 (/dev/console) leaked on lvm invocation. Parent PID 1: /nix/store/g5d2xbgp9js6phwlvkjbkpy6gf1cfj06-extra-utils/bin/ash
mounting tmpfs on /...
mounting ../nix-store.squashfs on /nix/.ro-store...
mounting tmpfs on /nix/.rw-store...
mounting overlay on /nix/store...

<<< NixOS Stage 2 >>>

running activation script...
setting up /etc...
starting systemd...

Welcome to NixOS 24.11 (Vicuna)!

[  OK  ] Created slice Slice /system/getty.
[  OK  ] Created slice Slice /system/modprobe.
[  OK  ] Created slice Slice /system/serial-getty.
[  OK  ] Created slice User and Session Slice.
[  OK  ] Started Dispatch Password Requests to Console Directory Watch.
[  OK  ] Started Forward Password Requests to Wall Directory Watch.
         Expecting device /dev/ttyS1...
[  OK  ] Reached target Local Encrypted Volumes.
[  OK  ] Reached target Containers.
[  OK  ] Reached target Path Units.
[  OK  ] Reached target Remote File Systems.
[  OK  ] Reached target Slice Units.
[  OK  ] Reached target Swaps.
[  OK  ] Listening on Process Core Dump Socket.
[  OK  ] Listening on Credential Encryption/Decryption.
[  OK  ] Listening on Journal Socket (/dev/log).
[  OK  ] Listening on Journal Sockets.
[  OK  ] Listening on Userspace Out-Of-Memory (OOM) Killer Socket.
[  OK  ] Listening on udev Control Socket.
[  OK  ] Listening on udev Kernel Socket.
         Mounting Huge Pages File System...
         Mounting POSIX Message Queue File System...
         Mounting Kernel Debug File System...
         Starting Create List of Static Device Nodes...
         Starting Load Kernel Module configfs...
         Starting Load Kernel Module drm...
         Starting Load Kernel Module efi_pstore...
         Starting Load Kernel Module fuse...
         Starting mount-pstore.service...
         Starting Journal Service...
         Starting Load Kernel Modules...
         Starting Remount Root and Kernel File Systems...
         Starting Coldplug All udev Devices...
[  OK  ] Mounted Huge Pages File System.
[  OK  ] Mounted POSIX Message Queue File System.
[  OK  ] Mounted Kernel Debug File System.
[  OK  ] Finished Create List of Static Device Nodes.
[  OK  ] Finished Load Kernel Module configfs.
[  OK  ] Finished Load Kernel Module drm.
[  OK  ] Finished Load Kernel Module efi_pstore.
[  OK  ] Finished Load Kernel Module fuse.
[  OK  ] Started Journal Service.
[  OK  ] Finished Load Kernel Modules.
[  OK  ] Finished Remount Root and Kernel File Systems.
         Mounting FUSE Control File System...
         Mounting Kernel Configuration File System...
         Starting Flush Journal to Persistent Storage...
         Starting Load/Save OS Random Seed...
         Starting Apply Kernel Variables...
         Starting Create Static Device Nodes in /dev gracefully...
[  OK  ] Mounted FUSE Control File System.
[  OK  ] Mounted Kernel Configuration File System.
[  OK  ] Finished Flush Journal to Persistent Storage.
[  OK  ] Finished Load/Save OS Random Seed.
[  OK  ] Reached target First Boot Complete.
[  OK  ] Finished Apply Kernel Variables.
[  OK  ] Finished Create Static Device Nodes in /dev gracefully.
         Starting Create Static Device Nodes in /dev...
[  OK  ] Finished Coldplug All udev Devices.
[  OK  ] Finished Create Static Device Nodes in /dev.
[  OK  ] Reached target Preparation for Local File Systems.
         Starting Rule-based Manager for Device Events and Files...
         Mounting /run/wrappers...
[  OK  ] Mounted /run/wrappers.
[  OK  ] Reached target Local File Systems.
[  OK  ] Listening on Boot Entries Service Socket.
         Starting Create SUID/SGID Wrappers...
         Starting Save Transient machine-id to Disk...
         Starting Create System Files and Directories...
[  OK  ] Finished Save Transient machine-id to Disk.
[  OK  ] Finished Create System Files and Directories.
         Starting Rebuild Journal Catalog...
         Starting Userspace Out-Of-Memory (OOM) Killer...
         Starting Network Time Synchronization...
         Starting Record System Boot/Shutdown in UTMP...
[  OK  ] Started Rule-based Manager for Device Events and Files.
[  OK  ] Finished Rebuild Journal Catalog.
[  OK  ] Finished Record System Boot/Shutdown in UTMP.
         Starting Update is Completed...
[  OK  ] Finished Update is Completed.
[  OK  ] Started Userspace Out-Of-Memory (OOM) Killer.
[  OK  ] Found device /dev/ttyS1.
[  OK  ] Finished Create SUID/SGID Wrappers.
[  OK  ] Finished mount-pstore.service.
[  OK  ] Started Network Time Synchronization.
[  OK  ] Reached target System Initialization.
[  OK  ] Started Discard unused filesystem blocks once a week.
[  OK  ] Started logrotate.timer.
[  OK  ] Started Daily Cleanup of Temporary Directories.
[  OK  ] Reached target Timer Units.
[  OK  ] Listening on D-Bus System Message Bus Socket.
[  OK  ] Listening on Nix Daemon Socket.
[  OK  ] Listening on Hostname Service Socket.
[  OK  ] Reached target Socket Units.
[  OK  ] Reached target Basic System.
         Starting Kernel Auditing...
[  OK  ] Started blade-controller.service.
         Starting Logrotate configuration check...
         Starting Name Service Cache Daemon (nsncd)...
[  OK  ] Started Reset console on configuration changes.
         Starting resolvconf update...
         Starting D-Bus System Message Bus...
[  OK  ] Finished Logrotate configuration check.
[  OK  ] Finished Kernel Auditing.
[  OK  ] Started Name Service Cache Daemon (nsncd).
[  OK  ] Reached target Host and Network Name Lookups.
[  OK  ] Reached target User and Group Name Lookups.
         Starting User Login Management...
[  OK  ] Started D-Bus System Message Bus.
         Starting Virtual Console Setup...
[  OK  ] Started User Login Management.
[  OK  ] Stopped target Host and Network Name Lookups.
         Stopping Host and Network Name Lookups...
[  OK  ] Stopped target User and Group Name Lookups.
         Stopping User and Group Name Lookups...
         Stopping Name Service Cache Daemon (nsncd)...
[  OK  ] Stopped Name Service Cache Daemon (nsncd).
         Starting Name Service Cache Daemon (nsncd)...
[  OK  ] Finished resolvconf update.
[  OK  ] Started Name Service Cache Daemon (nsncd).
[  OK  ] Reached target Preparation for Network.
[  OK  ] Reached target Host and Network Name Lookups.
[  OK  ] Reached target User and Group Name Lookups.
         Starting DHCP Client...
         Starting Networking Setup...
[  OK  ] Finished Virtual Console Setup.
[  OK  ] Finished Networking Setup.
         Starting Extra networking commands....
[  OK  ] Finished Extra networking commands..
[  OK  ] Reached target Network.
         Starting SSH Daemon...
         Starting Permit User Sessions...
[  OK  ] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
[  OK  ] Finished Permit User Sessions.
[  OK  ] Started Getty on tty1.
[  OK  ] Started Serial Getty on ttyS1.
[  OK  ] Reached target Login Prompts.


<<< Welcome to NixOS 24.11pre-git (aarch64) - ttyS1 >>>

Run 'nixos-help' for the NixOS manual.

beamformer login:
```